### PR TITLE
add duplicate and paste handler

### DIFF
--- a/src/actions/actionDuplicateSelection.tsx
+++ b/src/actions/actionDuplicateSelection.tsx
@@ -87,7 +87,7 @@ const duplicateElements = (
   const oldIdToDuplicatedId = new Map();
 
   const duplicateAndOffsetElement = (element: ExcalidrawElement) => {
-    const newElement = duplicateElement(
+    const _newElement = duplicateElement(
       appState.editingGroupId,
       groupIdMap,
       element,
@@ -96,6 +96,7 @@ const duplicateElements = (
         y: element.y + GRID_SIZE / 2,
       },
     );
+    const newElement = appState.externalToParkalotElement(_newElement)!;
     oldIdToDuplicatedId.set(element.id, newElement.id);
     oldElements.push(element);
     newElements.push(newElement);

--- a/src/actions/actionDuplicateSelection.tsx
+++ b/src/actions/actionDuplicateSelection.tsx
@@ -35,7 +35,15 @@ import {
 export const actionDuplicateSelection = register({
   name: "duplicateSelection",
   trackEvent: { category: "element" },
-  perform: (elements, appState) => {
+  perform: (_elements, appState) => {
+    const maybeElements = _elements.map(appState.externalToParkalotElement);
+
+    if (maybeElements.some((elements) => typeof elements === "undefined")) {
+      return false;
+    }
+
+    const elements = maybeElements as ExcalidrawElement[];
+
     // duplicate selected point(s) if editing a line
     if (appState.editingLinearElement) {
       const ret = LinearElementEditor.duplicateSelectedPoints(appState);

--- a/src/actions/actionDuplicateSelection.tsx
+++ b/src/actions/actionDuplicateSelection.tsx
@@ -35,15 +35,7 @@ import {
 export const actionDuplicateSelection = register({
   name: "duplicateSelection",
   trackEvent: { category: "element" },
-  perform: (_elements, appState) => {
-    const maybeElements = _elements.map(appState.externalToParkalotElement);
-
-    if (maybeElements.some((elements) => typeof elements === "undefined")) {
-      return false;
-    }
-
-    const elements = maybeElements as ExcalidrawElement[];
-
+  perform: (elements, appState) => {
     // duplicate selected point(s) if editing a line
     if (appState.editingLinearElement) {
       const ret = LinearElementEditor.duplicateSelectedPoints(appState);
@@ -116,6 +108,17 @@ const duplicateElements = (
       includeElementsInFrames: true,
     }),
   );
+
+  let areValidElemets = true;
+  idsOfElementsToDuplicate.forEach((element) => {
+    if (!appState.externalToParkalotElement(element)) {
+      areValidElemets = false;
+    }
+  });
+
+  if (!areValidElemets) {
+    return { elements, appState };
+  }
 
   // Ids of elements that have already been processed so we don't push them
   // into the array twice if we end up backtracking when retrieving

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -7,9 +7,12 @@ import {
   EXPORT_SCALES,
   THEME,
 } from "./constants";
+import { ExcalidrawElement } from "./element/types";
 import { t } from "./i18n";
 import { AppState, NormalizedZoomValue } from "./types";
 import { getDateTime } from "./utils";
+
+const externalToParkalotElement = (element: ExcalidrawElement) => element;
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
   ? devicePixelRatio
@@ -106,6 +109,7 @@ export const getDefaultAppState = (): Omit<
     },
     objectsSnapModeEnabled: false,
     disableCanvasDoubleClick: false,
+    externalToParkalotElement,
   };
 };
 
@@ -217,6 +221,7 @@ const APP_STATE_STORAGE_CONF = (<
   originSnapOffset: { browser: false, export: false, server: false },
   objectsSnapModeEnabled: { browser: true, export: false, server: false },
   disableCanvasDoubleClick: { browser: false, export: false, server: false },
+  externalToParkalotElement: { browser: false, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2293,6 +2293,16 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
+      const maybeElements = data.elements?.map((element) =>
+        this.state.externalToParkalotElement(element),
+      );
+
+      if (maybeElements?.some((elements) => elements === undefined)) {
+        return;
+      }
+
+      data.elements = maybeElements as ExcalidrawElement[] | undefined;
+
       if (this.props.onPaste) {
         try {
           if ((await this.props.onPaste(data, event)) === false) {
@@ -2360,7 +2370,19 @@ class App extends React.Component<AppProps, AppState> {
     retainSeed?: boolean;
     fitToContent?: boolean;
   }) => {
-    const elements = restoreElements(opts.elements, null, undefined);
+    const maybeElements = opts.elements.map(
+      this.state.externalToParkalotElement,
+    );
+
+    if (maybeElements.some((elements) => elements === undefined)) {
+      return;
+    }
+
+    const elements = restoreElements(
+      maybeElements as ExcalidrawElement[],
+      null,
+      undefined,
+    );
     const [minX, minY, maxX, maxY] = getCommonBounds(elements);
 
     const elementsCenterX = distance(minX, maxX) / 2;
@@ -6261,6 +6283,14 @@ class App extends React.Component<AppProps, AppState> {
             // Move the currently selected elements to the top of the z index stack, and
             // put the duplicates where the selected elements used to be.
             // (the origin point where the dragging started)
+
+            const maybeElements = pointerDownState.hit.allHitElements.map(
+              this.state.externalToParkalotElement,
+            );
+
+            if (maybeElements.some((element) => element === undefined)) {
+              return;
+            }
 
             pointerDownState.hit.hasBeenDuplicated = true;
 

--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -988,6 +988,10 @@ export class LinearElementEditor {
       return false;
     }
 
+    if (!appState.externalToParkalotElement(element)) {
+      return false;
+    }
+
     const { points } = element;
 
     const nextSelectedIndices: number[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,9 @@ export type AppState = {
   } | null;
   objectsSnapModeEnabled: boolean;
   disableCanvasDoubleClick: boolean;
+  externalToParkalotElement: (
+    element: ExcalidrawElement,
+  ) => ExcalidrawElement | undefined;
 };
 
 export type UIAppState = Omit<


### PR DESCRIPTION
In Parkalot we can do now:

``` tsx
export const externalToParkalotElement = (
  element: ExcalidrawElement
): ExcalidrawElement | undefined => {
   const libraryElement = LIBRARY_SKELETONS.find((skeleton) => {
    return (
      element.customData?.type === skeleton.customData?.type &&
      element.type === skeleton.type
    );
  });

  if (libraryElement) {
    return {
      ...element,
      link: null,
      customData: {
        ...element.customData,
        id: libraryElement?.customData?.id,
      },
    };
  }
};
```